### PR TITLE
おにぎりとお客さんのカウントリセット、難易度調整

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ const onigiriData = [
 ];
 
 let totalSales = 0; // 合計売り上げ金額
-const pricePerOnigiri = 100; // 1つのおにぎりの価格
+const pricePerOnigiri = 200; // 1つのおにぎりの価格
 let currentOrderCount = 3;  // 初めの注文数
 let currentOrder = {};  // 注文を格納する変数
 
@@ -46,6 +46,21 @@ function startGame() {
   document.getElementById("instructions").style.display = "none";
   document.getElementById("game").style.display = "block";
 
+      // おにぎりのカウントをリセット
+      for (const onigiri of onigiriData) {
+        onigiriCounts[onigiri.label] = 0;
+        const containers = document.querySelectorAll('.onigiri-container');
+        containers.forEach(container => {
+            if (container.querySelector('.label').textContent === onigiri.label) {
+                const countSpan = container.querySelector('.count');
+                const minusButton = container.querySelector('button');
+                countSpan.textContent = 0;
+                countSpan.style.display = 'none';  // カウントを非表示に
+                minusButton.style.display = 'none'; // マイナスボタンを非表示に
+            }
+        });
+    }
+
   // 注文を生成
   const orders = generateOrder(currentOrderCount);
   const orderDiv = document.getElementById("order");
@@ -55,16 +70,15 @@ function startGame() {
       document.getElementById("greeting").textContent = "";
       orderDiv.textContent = orders.join("、 ") + "ください。";
 
-      // さらに5秒後に注文内容を消す
-      setTimeout(() => {
-          orderDiv.textContent = "";
-      }, 5000);
+  // さらに(おにぎりの個数 + 1)秒後に注文内容を消す
+  setTimeout(() => {
+    orderDiv.textContent = "";
+  }, (currentOrderCount + 1) * 1000);
   }, 1000);  // 1秒後に実行
-
-  currentOrderCount++;  // 次の注文のために注文数を増やす
 }
 
 function checkOrder() {
+  document.getElementById("order").textContent = "";  // 注文内容をクリア
   for (const [label, count] of Object.entries(currentOrder)) {
       if (!onigiriCounts[label] || onigiriCounts[label] !== count) {
           gameOver();
@@ -84,11 +98,14 @@ function thankYou() {
   // 2秒後にメッセージを非表示にしてゲームを再開する
   setTimeout(() => {
       messageDiv.style.display = "none";  // メッセージを非表示にする
+      currentOrderCount++;  // 正しい注文が提供された後に注文数を増加させる
       startGame();
   }, 2000);
 }
 
 function gameOver() {
+  currentOrderCount = 3;  // ゲームオーバー時に注文数をリセット
+
   const gameOverPopup = document.getElementById("gameOverPopup");
   const gameOverMessage = document.getElementById("gameOverMessage");
   const postToXButton = document.getElementById("postToX");


### PR DESCRIPTION
- 二人目以降の注文時に一つ前のおにぎり個数が残っていたのでリセット
- ゲームオーバー時、もう一度ボタンを押すとおにぎり個数が最初からになっていなかったのでリセット
- 難易度調整：注文内容表示時間を一律5秒からおにぎりの個数+1秒へ変更